### PR TITLE
ci(github): 完成 GitHub 仓库流水线

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,11 +131,10 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
-          path: better-thesis
 
       - name: Store CI_PROJECT_DIR
         run: |
-          CI_PROJECT_DIR="./better-thesis"
+          CI_PROJECT_DIR="${pwd}"
           echo "CI_PROJECT_DIR=$CI_PROJECT_DIR" >> $GITHUB_ENV
 
       - name: Checkout Packages fork
@@ -148,52 +147,58 @@ jobs:
           persist-credentials: true
           path: sysu-fork
 
-      - name: Store MODERN_SYSU_THESIS
+      - name: Check current directory
         run: |
-          MODERN_SYSU_THESIS=./sysu-fork/packages/preview/modern-sysu-thesis
-          echo "MODERN_SYSU_THESIS=$MODERN_SYSU_THESIS" >> $GITHUB_ENV
+          pwd
+          ls
+          echo ${pwd}
+      # - name: Store MODERN_SYSU_THESIS
+      #   run: |
+      #     MODERN_SYSU_THESIS="${pwd}/sysu-fork/packages/preview/modern-sysu-thesis"
+      #     echo "MODERN_SYSU_THESIS=$MODERN_SYSU_THESIS" >> $GITHUB_ENV
 
-      - name: switch new branch for Packages
-        working-directory: $MODERN_SYSU_THESIS
-        run: |
-          git switch main
-          git switch -c $SEMVER
+      # - name: switch new branch for Packages
+      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
+      #   run: |
+      #     git switch main
+      #     git switch -c $SEMVER
 
-      - name: create new version directory
-        run: |
-          mkdir $SEMVER
+      # - name: create new version directory
+      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
+      #   run: |
+      #     mkdir $SEMVER
 
-      - name: Copy project files
-        working-directory: $MODERN_SYSU_THESIS/$SEMVER
-        run: |
-          cp $CI_PROJECT_DIR/LICENSE .
-          cp $CI_PROJECT_DIR/README.md .
-          cp $CI_PROJECT_DIR/typst.toml .
-          cp $CI_PROJECT_DIR/thumbnail.png .
-          cp $CI_PROJECT_DIR/lib.typ .
-          cp -r $CI_PROJECT_DIR/assets .
-          cp -r $CI_PROJECT_DIR/layouts .
-          cp -r $CI_PROJECT_DIR/utils .
-          cp -r $CI_PROJECT_DIR/pages .
-          cp -r $CI_PROJECT_DIR/specifications .
-          cp -r $CI_PROJECT_DIR/template .
+      # - name: Copy project files
+      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
+      #   run: |
+      #     cp $CI_PROJECT_DIR/LICENSE .
+      #     cp $CI_PROJECT_DIR/README.md .
+      #     cp $CI_PROJECT_DIR/typst.toml .
+      #     cp $CI_PROJECT_DIR/thumbnail.png .
+      #     cp $CI_PROJECT_DIR/lib.typ .
+      #     cp -r $CI_PROJECT_DIR/assets .
+      #     cp -r $CI_PROJECT_DIR/layouts .
+      #     cp -r $CI_PROJECT_DIR/utils .
+      #     cp -r $CI_PROJECT_DIR/pages .
+      #     cp -r $CI_PROJECT_DIR/specifications .
+      #     cp -r $CI_PROJECT_DIR/template .
 
-      - name: Switch to preview import
-        working-directory: $MODERN_SYSU_THESIS/$SEMVER
-        run: |
-          sd '// #import "@preview/modern-sysu-thesis:' '#import "@preview/modern-sysu-thesis:' ./template/thesis.typ
-          sd '#import "/lib.typ":' '// #import "lib.typ":' ./template/thesis.typ
+      # - name: Switch to preview import
+      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
+      #   run: |
+      #     sd '// #import "@preview/modern-sysu-thesis:' '#import "@preview/modern-sysu-thesis:' ./template/thesis.typ
+      #     sd '#import "/lib.typ":' '// #import "lib.typ":' ./template/thesis.typ
 
-      - name: Configure triger user for git
-        working-directory: $MODERN_SYSU_THESIS/$SEMVER
-        run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor }}@users.noreply.github.com"
+      # - name: Configure triger user for git
+      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
+      #   run: |
+      #     git config user.name "${{ github.actor }}"
+      #     git config user.email "${{ github.actor }}@users.noreply.github.com"
 
-      - name: Commit to Packages
-        working-directory: $MODERN_SYSU_THESIS/$SEMVER
-        run: |
-          git status
-          git add .
-          git commit -m "chore(release):prepare for modern-sysu-thesis:$SEMVER"
-          git push --set-upstream origin $SEMVER
+      # - name: Commit to Packages
+      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
+      #   run: |
+      #     git status
+      #     git add .
+      #     git commit -m "chore(release):prepare for modern-sysu-thesis:$SEMVER"
+      #     git push --set-upstream origin $SEMVER

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,10 +156,14 @@ jobs:
           git switch main
           git switch -c $SEMVER
 
+      - run: ls
+
       - name: create new version directory
         run: |
           mkdir $SEMVER
           cd $SEMVER
+
+      - run: ls
 
       - name: Copy project files
         run: |
@@ -174,6 +178,8 @@ jobs:
           cp -r $CI_PROJECT_DIR/pages .
           cp -r $CI_PROJECT_DIR/specifications .
           cp -r $CI_PROJECT_DIR/template .
+
+      - run: ls
 
       - name: Switch to preview import
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Store CI_PROJECT_DIR
         run: |
-          CI_PROJECT_DIR="${pwd}"
+          CI_PROJECT_DIR="$(pwd)"
           echo "CI_PROJECT_DIR=$CI_PROJECT_DIR" >> $GITHUB_ENV
 
       - name: Checkout Packages fork
@@ -147,7 +147,51 @@ jobs:
           persist-credentials: true
           path: sysu-fork
 
-      - name: Check current directory
+      - name: Store MODERN_SYSU_THESIS
+        run: |
+          MODERN_SYSU_THESIS="$(pwd)/sysu-fork/packages/preview/modern-sysu-thesis"
+          echo "MODERN_SYSU_THESIS=$MODERN_SYSU_THESIS" >> $GITHUB_ENV
+
+      - name: switch new branch for Packages
+        working-directory: ${{ env.MODERN_SYSU_THESIS }}
+        run: |
+          git switch main
+          git switch -c $SEMVER
+
+      - name: create new version directory
+        working-directory: ${{ env.MODERN_SYSU_THESIS }}
+        run: |
+          mkdir $SEMVER
+
+      - name: Copy project files
+        working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
+        run: |
+          cp $CI_PROJECT_DIR/LICENSE .
+          cp $CI_PROJECT_DIR/README.md .
+          cp $CI_PROJECT_DIR/typst.toml .
+          cp $CI_PROJECT_DIR/thumbnail.png .
+          cp $CI_PROJECT_DIR/lib.typ .
+          cp -r $CI_PROJECT_DIR/assets .
+          cp -r $CI_PROJECT_DIR/layouts .
+          cp -r $CI_PROJECT_DIR/utils .
+          cp -r $CI_PROJECT_DIR/pages .
+          cp -r $CI_PROJECT_DIR/specifications .
+          cp -r $CI_PROJECT_DIR/template .
+
+      - name: Switch to preview import
+        working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
+        run: |
+          sd '// #import "@preview/modern-sysu-thesis:' '#import "@preview/modern-sysu-thesis:' ./template/thesis.typ
+          sd '#import "/lib.typ":' '// #import "lib.typ":' ./template/thesis.typ
+
+      - name: Configure triger user for git
+        working-directory: ${{ env.MODERN_SYSU_THESIS }}
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
+      - name: Commit to Packages
+        working-directory: ${{ env.MODERN_SYSU_THESIS }}
         run: |
           pwd
           ls

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,24 +148,23 @@ jobs:
           persist-credentials: true
           path: sysu-fork
 
-      - run: ls
+      - name: Store MODERN_SYSU_THESIS
+        run: |
+          MODERN_SYSU_THESIS=./sysu-fork/packages/preview/modern-sysu-thesis
+          echo "MODERN_SYSU_THESIS=$MODERN_SYSU_THESIS" >> $GITHUB_ENV
 
       - name: switch new branch for Packages
+        working-directory: $MODERN_SYSU_THESIS
         run: |
-          cd ./sysu-fork/packages/preview/modern-sysu-thesis
           git switch main
           git switch -c $SEMVER
-
-      - run: ls
 
       - name: create new version directory
         run: |
           mkdir $SEMVER
-          cd $SEMVER
-
-      - run: ls
 
       - name: Copy project files
+        working-directory: $MODERN_SYSU_THESIS/$SEMVER
         run: |
           cp $CI_PROJECT_DIR/LICENSE .
           cp $CI_PROJECT_DIR/README.md .
@@ -179,19 +178,20 @@ jobs:
           cp -r $CI_PROJECT_DIR/specifications .
           cp -r $CI_PROJECT_DIR/template .
 
-      - run: ls
-
       - name: Switch to preview import
+        working-directory: $MODERN_SYSU_THESIS/$SEMVER
         run: |
           sd '// #import "@preview/modern-sysu-thesis:' '#import "@preview/modern-sysu-thesis:' ./template/thesis.typ
           sd '#import "/lib.typ":' '// #import "lib.typ":' ./template/thesis.typ
 
       - name: Configure triger user for git
+        working-directory: $MODERN_SYSU_THESIS/$SEMVER
         run: |
           git config user.name "${{ github.actor }}"
           git config user.email "${{ github.actor }}@users.noreply.github.com"
 
       - name: Commit to Packages
+        working-directory: $MODERN_SYSU_THESIS/$SEMVER
         run: |
           git status
           git add .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,13 +146,13 @@ jobs:
           fetch-tags: true
           token: ${{ secrets.TYPST_PACKAGES_FORK_TOKEN }}
           persist-credentials: true
-          path: sysu-packages
+          path: sysu-fork
 
       - run: ls
 
       - name: switch new branch for Packages
         run: |
-          cd ./sysu-packages/preview/modern-sysu-thesis
+          cd ./sysu-fork/packages/preview/modern-sysu-thesis
           git switch main
           git switch -c $SEMVER
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,56 +193,7 @@ jobs:
       - name: Commit to Packages
         working-directory: ${{ env.MODERN_SYSU_THESIS }}
         run: |
-          pwd
-          ls
-          echo ${pwd}
-      # - name: Store MODERN_SYSU_THESIS
-      #   run: |
-      #     MODERN_SYSU_THESIS="${pwd}/sysu-fork/packages/preview/modern-sysu-thesis"
-      #     echo "MODERN_SYSU_THESIS=$MODERN_SYSU_THESIS" >> $GITHUB_ENV
-
-      # - name: switch new branch for Packages
-      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
-      #   run: |
-      #     git switch main
-      #     git switch -c $SEMVER
-
-      # - name: create new version directory
-      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
-      #   run: |
-      #     mkdir $SEMVER
-
-      # - name: Copy project files
-      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
-      #   run: |
-      #     cp $CI_PROJECT_DIR/LICENSE .
-      #     cp $CI_PROJECT_DIR/README.md .
-      #     cp $CI_PROJECT_DIR/typst.toml .
-      #     cp $CI_PROJECT_DIR/thumbnail.png .
-      #     cp $CI_PROJECT_DIR/lib.typ .
-      #     cp -r $CI_PROJECT_DIR/assets .
-      #     cp -r $CI_PROJECT_DIR/layouts .
-      #     cp -r $CI_PROJECT_DIR/utils .
-      #     cp -r $CI_PROJECT_DIR/pages .
-      #     cp -r $CI_PROJECT_DIR/specifications .
-      #     cp -r $CI_PROJECT_DIR/template .
-
-      # - name: Switch to preview import
-      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
-      #   run: |
-      #     sd '// #import "@preview/modern-sysu-thesis:' '#import "@preview/modern-sysu-thesis:' ./template/thesis.typ
-      #     sd '#import "/lib.typ":' '// #import "lib.typ":' ./template/thesis.typ
-
-      # - name: Configure triger user for git
-      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
-      #   run: |
-      #     git config user.name "${{ github.actor }}"
-      #     git config user.email "${{ github.actor }}@users.noreply.github.com"
-
-      # - name: Commit to Packages
-      #   working-directory: ${{ env.MODERN_SYSU_THESIS }}
-      #   run: |
-      #     git status
-      #     git add .
-      #     git commit -m "chore(release):prepare for modern-sysu-thesis:$SEMVER"
-      #     git push --set-upstream origin $SEMVER
+          git status
+          git add .
+          git commit -m "chore(release):prepare for modern-sysu-thesis:$SEMVER"
+          git push --set-upstream origin $SEMVER

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ on: workflow_dispatch
 
 jobs:
   restore-tools:
-    if: github.ref_name == github.event.repository.default_branch
+    # if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       - id: toolchain
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/git/db/
 
   bump-version:
-    if: github.ref_name == github.event.repository.default_branch
+    # if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     needs:
       - restore-tools
@@ -106,7 +106,7 @@ jobs:
         run: git push origin
 
   publish2universe:
-    if: github.ref_name == github.event.repository.default_branch
+    # if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     needs:
       - bump-version
@@ -147,6 +147,8 @@ jobs:
           token: ${{ secrets.TYPST_PACKAGES_FORK_TOKEN }}
           persist-credentials: true
           path: sysu-packages
+
+      - run: ls
 
       - name: switch new branch for Packages
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ on: workflow_dispatch
 
 jobs:
   restore-tools:
-    # if: github.ref_name == github.event.repository.default_branch
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     steps:
       - id: toolchain
@@ -37,7 +37,7 @@ jobs:
             ~/.cargo/git/db/
 
   bump-version:
-    # if: github.ref_name == github.event.repository.default_branch
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     needs:
       - restore-tools
@@ -106,7 +106,7 @@ jobs:
         run: git push origin
 
   publish2universe:
-    # if: github.ref_name == github.event.repository.default_branch
+    if: github.ref_name == github.event.repository.default_branch
     runs-on: ubuntu-latest
     needs:
       - bump-version


### PR DESCRIPTION
该 PR 复刻了 GitLab CI 里的主要功能：
- [x] 在 web 页面上才可触发发布流水线
- [x] 自动生成 version-bumped-up 提交
- [x] 前述提交生成后：
    - [x] 整理需要提交新版本的文件，并生成新版本分支与提交
    - [x] 自动推送到 [sysu/packages](https://github.com/sysu/packages)。

然而由于 GitLab CI 和 GitHub Actions 机制的不同，还有以下问题待解决：
- GitHub 仓库里的 Actions 页，允许发布流水线使用不同分支运行。目前通过 jobs 的 if 条件限制仅在 `default_branch` 上执行流水线，而不能限制非默认分支触发
- 缓存机制问题。目前检查流水线缓存是按照PR区分，因此每一个 PR 就需要重新生成缓存，导致流水线重复运行无效工作。
- 触发者需要绕过推送退则限制问题。只有触发者绕过“禁止在 `default_branch`上推送提交”的规则，才可以成功执行发布流水线。