### PR TITLE
ci(github): 在发布流水线中增加安装 typst-cli

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Install sd
         run: cargo install sd || true
 
+      - name: Install Typst
+        run: cargo install typst-cli || true
+
       - name: Cache Cargo
         uses: actions/cache/save@v4
         with:


### PR DESCRIPTION
受限于[GitHub Worlflow 有限与其他分支共享缓存机制](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache)，需在默认分支提前换准好 typst-cli 工具，以缓解后续其他分支重复生成缓存问题。