### PR TITLE
fix(template): resolve function with the right spec

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,9 @@ jobs:
       - name: Switch to preview import
         working-directory: ${{ env.MODERN_SYSU_THESIS }}/${{ env.SEMVER }}
         run: |
-          sd '// #import "@preview/modern-sysu-thesis:' '#import "@preview/modern-sysu-thesis:' ./template/thesis.typ
+          # regular expression from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+          SEMVER_REGEX='(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?'
+          sd "// #import \"@preview/modern-sysu-thesis:($SEMVER_REGEX)\": postgraduate" '#import "@preview/modern-sysu-thesis:$1": postgraduate' ./template/thesis.typ
           sd '#import "/lib.typ":' '// #import "lib.typ":' ./template/thesis.typ
 
       - name: Configure triger user for git

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -1,9 +1,16 @@
-// 建议在正式编辑论文时，采用 typst.app 中的已发布版本模板
-// #import "@preview/modern-sysu-thesis:0.4.1": bachelor as thesis
-
 // 仅供开发调试使用
+// #import "/lib.typ": bachelor as thesis
 #import "/lib.typ": postgraduate as thesis
+
+// 建议在正式编辑论文时，采用 typst.app 中的已发布版本模板
+// 本科生毕业论文模板
+// #import "@preview/modern-sysu-thesis:0.4.1": bachelor as thesis
+// #import thesis: abstract, acknowledgement, appendix
+
+// 硕博士毕业论文模板
+// #import "@preview/modern-sysu-thesis:0.4.1": postgraduate as thesis
 #import thesis: abstract, acknowledgement, appendix, contents
+
 
 // 你首先应该安装 https://gitlab.com/sysu-gitlab/thesis-template/better-thesis/-/tree/main/fonts 里的所有字体，
 // 如果是 Web App 上编辑，你应该手动上传这些字体文件，否则不能正常使用「楷体」和「仿宋」，导致显示错误。


### PR DESCRIPTION
发送给上游的 PR <https://github.com/typst/packages/pull/4361> 报错无法解析，定位到问题在于硕博士模板多了 `content` 函数，在发版时自动反注释引用了本科生毕业论文模板，于是找不到了 `contents` 