### PR TITLE
fix(Win_install): 尝试修复 Windows 安装脚本的一些错误行为

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 # macOS
 .DS_Store
+CLAUDE.md

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 ### Windows 用户
 
 1. [下载本仓库][download]，或者使用 `git clone https://github.com/sysu/better-thesis` 命令克隆本仓库。
-2. 在本地仓库目录打开终端，执行 `.\install_typst.ps1`，等待 Typst 安装完成。
+2. 在本地仓库目录打开终端，执行 `powershell -ExecutionPolicy Bypass -File .\install_typst.ps1`，等待 Typst 安装完成。
 
 > Windows 默认具有脚本执行限制策略，在默认情况下，直接双击或右键运行脚本将无法运行，因此您需要通过该方法绕过该限制。您也可以参考 [about_Execution_Policies -PowerShell | Microsoft Learn](https://learn.microsoft.com/zh-cn/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.6) 来调整适合你的执行策略。
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@
 ### Windows 用户
 
 1. [下载本仓库][download]，或者使用 `git clone https://github.com/sysu/better-thesis` 命令克隆本仓库。
-2. 右键 `install_typst.ps1` 文件，选择“用 Powershell 运行”，等待 Typst 安装完成。
+2. 在本地仓库目录打开终端，执行 `.\install_typst.ps1`，等待 Typst 安装完成。
+
+> Windows 默认具有脚本执行限制策略，在默认情况下，直接双击或右键运行脚本将无法运行，因此您需要通过该方法绕过该限制。您也可以参考 [about_Execution_Policies -PowerShell | Microsoft Learn](https://learn.microsoft.com/zh-cn/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.6) 来调整适合你的执行策略。
+
 3. 根据 [Typst 文档](https://typst.app/docs/)，参考 [项目结构](#项目结构) 中的说明，按照你的需要修改论文的各个部分。
 4. 双击运行 `compile.bat`，即可生成 `thesis.pdf` 文件。
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@
 2. 在本地仓库目录打开终端，执行 `powershell -ExecutionPolicy Bypass -File .\install_typst.ps1`，等待 Typst 安装完成。
 
 > Windows 默认具有脚本执行限制策略，在默认情况下，直接双击或右键运行脚本将无法运行，因此您需要通过该方法绕过该限制。您也可以参考 [about_Execution_Policies -PowerShell | Microsoft Learn](https://learn.microsoft.com/zh-cn/powershell/module/microsoft.powershell.core/about/about_execution_policies?view=powershell-7.6) 来调整适合你的执行策略。
+>
+> Windows 用户如果在编译时遇到 `link.exe not found` 或类似错误，请检查 C++ 开发环境是否正常，如未配置，请安装 Visual Studio Build Tools 并勾选 `Desktop development with C++`：https://visualstudio.microsoft.com/visual-cpp-build-tools/
 
 3. 根据 [Typst 文档](https://typst.app/docs/)，参考 [项目结构](#项目结构) 中的说明，按照你的需要修改论文的各个部分。
 4. 双击运行 `compile.bat`，即可生成 `thesis.pdf` 文件。

--- a/install_typst.ps1
+++ b/install_typst.ps1
@@ -16,7 +16,7 @@ else {
 
   # Run the installer
   Write-Output "运行 Rustup 安装程序..."
-  Start-Process -FilePath $Env:Temp/rustup-init.exe -Args -y
+  Start-Process -FilePath $Env:Temp/rustup-init.exe -ArgumentList "-y" -Wait -NoNewWindow
 
   # Add Rustup to the PATH
   Write-Output "将 Rustup 添加到 PATH 环境变量..."
@@ -45,7 +45,7 @@ else {
 replace-with = "tuna"
 
 [source.tuna]
-registry = "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"
+registry = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"
 '@
   }
 }


### PR DESCRIPTION
## 已修改

修正 Windows 安装脚本使用完整 crates.io 仓库、不等待 Rust 初始化完成就继续以及不能正确提供绕过运行限制策略的问题。

## 修改方法

1. 更正 README 中关于脚本的使用说明；
2. 要求 PowerShell 必须等待 Rust 初始化进程完成后再继续执行；
3. 使用 TUNA 稀疏化镜像而不是拉取整个仓库。

## 验证

<details>
    <summary>更正后脚本安装执行的屏幕录制</summary>
原视频时长9分钟，受限于 GitHub 附件大小限制，已对视频做压缩加速处理。验证环境为全新 Windows 10 LTSC 2021，仅安装了 Git For Windows 和 Visual Studio 2026 （C++ 桌面开发必要工具链）。

https://github.com/user-attachments/assets/421c1d60-57c5-4ace-bf4d-14bd68e0d853


</details>

## 安全更新？

不是。该更改不具有任何安全性更改。

## 破坏性更改？

不是。该更改不具有任何破坏性更改，应该可以安全切换到新的特性版本。