### PR TITLE
chore: 替换使用中大镜像源

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,13 @@ source $HOME/.cargo/env
 # 安装 Typst CLI
 cargo install typst-cli
 
-# 访问缓慢的话，执行以下命令设置清华镜像源，并从镜像站安装
+# 访问缓慢的话，执行以下命令设置中大镜像源，并从镜像站安装
 cat << EOF > $HOME/.cargo/config
 [source.crates-io]
-replace-with = "tuna"
+replace-with = "SysuMirror"
 
-[source.tuna]
-registry = "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"
+[source.SysuMirror]
+registry = "sparse+https://mirror.sysu.edu.cn/crates.io-index"
 EOF
 cargo install typst-cli
 ```

--- a/install_typst.ps1
+++ b/install_typst.ps1
@@ -42,10 +42,10 @@ else {
     New-Item -ItemType File -Path $env:USERPROFILE\.cargo\config
     Set-Content -Path $env:USERPROFILE\.cargo\config -Value @'
 [source.crates-io]
-replace-with = "tuna"
+replace-with = "SysuMirror"
 
-[source.tuna]
-registry = "sparse+https://mirrors.tuna.tsinghua.edu.cn/crates.io-index/"
+[source.SysuMirror]
+registry = "sparse+https://mirror.sysu.edu.cn/crates.io-index/"
 '@
   }
 }


### PR DESCRIPTION
## 已修改

将本地安装方法中，使用的 crates.io-index 镜像源由清华 TUNA 替换为中山大学镜像站可用的稀疏镜像。

## 修改原因

~当然是中大人当自强~（）

校内镜像站具有更佳的下载体验。

## 安全更新？

不是。该更改不具有任何安全性更改。

## 破坏性更改？

不是。该更改不具有任何破坏性更改，应该可以安全切换到新的特性版本。