### PR TITLE
feat(template): 为英语文本实现斜体调用以及其他 chore

### DIFF
--- a/specifications/bachelor/abstract-en.typ
+++ b/specifications/bachelor/abstract-en.typ
@@ -39,6 +39,15 @@ Both Chinese and English should be in seperated pages.
 
     // 摘要正文下方另起一行顶格打印“关键词”款项，后加冒号，多个关键词以逗号分隔。
     // （标题“Keywords”加粗）
-    *Keywords:* #context abstract-en-keywords.final().join(", ")
+    // 使用逐元素遍历渲染，每个元素直接作为 content 输出，单独处理分隔符
+    *Keywords:* #context {
+      let kws = abstract-en-keywords.final()
+      for (i, kw) in kws.enumerate() {
+        kw
+        if i < kws.len() - 1 {
+          [, ]
+        }
+      }
+    }
   ]
 }

--- a/specifications/bachelor/lib.typ
+++ b/specifications/bachelor/lib.typ
@@ -66,9 +66,13 @@
   // 论文信息参数处理。要求必须传递，且符合规格的参数
   assert(type(thesis-info) == dictionary)
   assert(type(thesis-info.title) == array or type(thesis-info.title) == str)
-  assert(type(thesis-info.title-en) == array
-    or type(thesis-info.title-en) == str
-  )
+  // 避免大面积破坏：同时允许接受 content 和 str
+  if type(thesis-info.title-en) == str {
+    thesis-info.title-en = thesis-info.title-en.split("\n")
+  } else if type(thesis-info.title-en) != array {
+    thesis-info.title-en = (thesis-info.title-en,)
+  }
+  assert(type(thesis-info.title-en) == array)
   // 论文信息默认参数。函数传入参数会完全覆盖参数值，因此需要提供默认参数补充。
   // 彩蛋：如果论文参数不传递作者参数，那么论文就会被署名论文模板作者
   let default-author = (

--- a/specifications/postgraduate/abstract-en.typ
+++ b/specifications/postgraduate/abstract-en.typ
@@ -44,6 +44,15 @@
 
     // 摘要正文下方另起一行顶格打印“关键词”款项，后加冒号，多个关键词以逗号分隔。
     // （标题“Keywords”加粗）
-    *Keywords:* #context abstract-en-keywords.final().join(", ")
+    // 使用逐元素遍历渲染，每个元素直接作为 content 输出，单独处理分隔符
+    *Keywords:* #context {
+      let kws = abstract-en-keywords.final()
+      for (i, kw) in kws.enumerate() {
+        kw
+        if i < kws.len() - 1 {
+          [, ]
+        }
+      }
+    }
   ]
 }

--- a/specifications/postgraduate/lib.typ
+++ b/specifications/postgraduate/lib.typ
@@ -62,9 +62,13 @@
   // 论文信息参数处理。要求必须传递，且符合规格的参数
   assert(type(thesis-info) == dictionary)
   assert(type(thesis-info.title) == array or type(thesis-info.title) == str)
-  assert(
-    type(thesis-info.title-en) == array or type(thesis-info.title-en) == str,
-  )
+  // 避免大面积破坏：同时允许接受 content 和 str
+  if type(thesis-info.title-en) == str {
+    thesis-info.title-en = thesis-info.title-en.split("\n")
+  } else if type(thesis-info.title-en) != array {
+    thesis-info.title-en = (thesis-info.title-en,)
+  }
+  assert(type(thesis-info.title-en) == array)
   // 论文信息默认参数。函数传入参数会完全覆盖参数值，因此需要提供默认参数补充。
   // 彩蛋：如果论文参数不传递作者参数，那么论文就会被署名论文模板作者
   let default-author = (

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -19,6 +19,18 @@
 // 此时，文字“Sun Yat-sen University”将以斜体效果呈现。
 #let ita(body) = text(style: "italic")[#body]
 
+// 摘要
+#abstract(
+  [博学、审问、慎思、明辨、笃行是中山大学的校训。],
+  keywords: ("中山大学", "校训", "学术研究"),
+)
+
+// 英文摘要：当您使用本科论文模板时，可将此处的注释取消以写入英文摘要。
+// #abstract-en(
+//   [Extensive learning, careful inquiry, prudent thinking, clear discernment, and resolute practice" is the motto of Sun Yat-sen University.],
+//   keywords: ("Sun Yat-sen University", "School Motto", "Academic Research"),
+// )
+
 #show: thesis.doc.with(
   // 毕业论文基本信息
   thesis-info: (
@@ -191,15 +203,3 @@ $ F_n = floor(1 / sqrt(5) phi.alt^n) $
 #acknowledgement[
   感谢 NJU-LUG，感谢 NJUThesis LaTeX 模板。
 ]
-
-// 摘要
-#abstract(
-  [博学、审问、慎思、明辨、笃行是中山大学的校训。],
-  keywords: ("中山大学", "校训", "学术研究"),
-)
-
-// 英文摘要：当您使用本科论文模板时，可将此处的注释取消以写入英文摘要。
-// #abstract-en(
-//   [Extensive learning, careful inquiry, prudent thinking, clear discernment, and resolute practice" is the motto of Sun Yat-sen University.],
-//   keywords: ("Sun Yat-sen University", "School Motto", "Academic Research"),
-// )

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -11,9 +11,13 @@
 // #import "@preview/modern-sysu-thesis:0.4.1": postgraduate as thesis
 #import thesis: abstract, acknowledgement, appendix, contents
 
-
 // 你首先应该安装 https://gitlab.com/sysu-gitlab/thesis-template/better-thesis/-/tree/main/fonts 里的所有字体，
 // 如果是 Web App 上编辑，你应该手动上传这些字体文件，否则不能正常使用「楷体」和「仿宋」，导致显示错误。
+
+// 定义斜体函数。在正文部分，若要使得某些文字（仅限英语）以斜体效果呈现，请像下面这样的示例调用：
+// #ita[Sun Yat-sen University]
+// 此时，文字“Sun Yat-sen University”将以斜体效果呈现。
+#let ita(body) = text(style: "italic")[#body]
 
 #show: thesis.doc.with(
   // 毕业论文基本信息

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -29,9 +29,12 @@
 )
 
 // 英文摘要：当您使用本科论文模板时，可将此处的注释取消以写入英文摘要。
+// 其中当您像这样调用 keywords 时：
+// keywords: ([Sun Yat-sen #ita[University]], [School Motto], [Academic Research]),
+// 实际效果为：包含三个关键词，其中“University”以斜体效果呈现。
 // #abstract-en(
 //   [Extensive learning, careful inquiry, prudent thinking, clear discernment, and resolute practice" is the motto of Sun Yat-sen University.],
-//   keywords: ("Sun Yat-sen University", "School Motto", "Academic Research"),
+//   keywords: ([Sun Yat-sen #ita[University]], [School Motto], [Academic Research]),
 // )
 
 #show: thesis.doc.with(

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -14,6 +14,9 @@
 // 你首先应该安装 https://gitlab.com/sysu-gitlab/thesis-template/better-thesis/-/tree/main/fonts 里的所有字体，
 // 如果是 Web App 上编辑，你应该手动上传这些字体文件，否则不能正常使用「楷体」和「仿宋」，导致显示错误。
 
+// 关闭 smart quote，避免英文引号自动转换为弯引号
+#set smartquote(enabled: false)
+
 // 定义斜体函数。在正文部分，若要使得某些文字（仅限英语）以斜体效果呈现，请像下面这样的示例调用：
 // #ita[Sun Yat-sen University]
 // 此时，文字“Sun Yat-sen University”将以斜体效果呈现。

--- a/template/thesis.typ
+++ b/template/thesis.typ
@@ -40,7 +40,10 @@
     // 论文标题，将展示在封面、扉页与页眉上
     // 多行标题请使用数组传入 `("thesis title", "with part next line")`，或使用换行符：`"thesis title\nwith part next line"`
     title: ("基于 Typst 的", "中山大学学位论文模板"),
-    title-en: "A Typst Template for SYSU thesis",
+    // 当您像这样调用 title-en 时：
+    // title-en: ([Hello SYSU], [Sun Yat-sen #ita[University]]),
+    // 实际效果为：“Hello SYSU”与“Sun Yat-sen University”将分为两行显示，其中“University”以斜体效果呈现。 
+    title-en: ([Hello SYSU], [Sun Yat-sen #ita[University]]),
     // 论文作者信息：学号、姓名、院系、专业、指导老师
     author: (
       sno: "1xxxxxxx",


### PR DESCRIPTION
该 PR 主要引入以下更改：

1. 在正文、英文标题、英文摘要处引入对斜体调用的支持。为实现这一点，它包含以下子更改：
    - 在 [`template/thesis.typ`](https://github.com/sysu/better-thesis/pull/41/changes#diff-127b04ad721966f593c08226eeb0ff77682e40c798c0856955ed9941b6947f33) 定义斜体函数，使得写作时可在 content 类型的部分使用它引入斜体效果；
    - 在 [`specifications/bachelor/lib.typ`](https://github.com/sysu/better-thesis/pull/41/changes#diff-a54a98a9dbf036dc844f952c7bef6dc73927e19fad42281f2d3366b113e552ec) 和 [specifications/postgraduate/lib.typ](https://github.com/sysu/better-thesis/pull/41/changes#diff-79a48df7c950fc17034e3b7f00b3cc6349afd65d099c3db9780363c124269ade) 中修改对传入参数的断言方式，将它们统一为 array 类型且接受 content 类型的传入，保持旧版兼容性的同时引入新特性；
    - 在 [`specifications/bachelor/abstract-en.typ`](https://github.com/sysu/better-thesis/pull/41/changes#diff-3a36efdb3733a508a7531f8251ebaef5064e42244c532d674f685cf1c8c739e0) 中修改 Keywords 的渲染方式，引入与上一条类似的特性。
2. 关闭 SmartQuote 功能，阻止在中英文混合环境中，英文语境下的引号被意外转换为中文引号。在 [`template/thesis.typ`](https://github.com/sysu/better-thesis/pull/41/changes#diff-127b04ad721966f593c08226eeb0ff77682e40c798c0856955ed9941b6947f33) 全局实现。
3. 调换摘要所在位置，使其更符合写作排版直觉。在[`template/thesis.typ`](https://github.com/sysu/better-thesis/pull/41/changes#diff-127b04ad721966f593c08226eeb0ff77682e40c798c0856955ed9941b6947f33) 实现。